### PR TITLE
Update def merge_groups(self): in svg.py

### DIFF
--- a/deepsvg/svglib/svg.py
+++ b/deepsvg/svglib/svg.py
@@ -249,8 +249,8 @@ class SVG:
 
     def merge_groups(self):
         path_group = self.svg_path_groups[0]
-        for path_group in self.svg_path_groups[1:]:
-            path_group.svg_paths.extend(path_group.svg_paths)
+        for group in self.svg_path_groups[1:]:
+            path_group.svg_paths.extend(group.svg_paths)
         self.svg_path_groups = [path_group]
         return self
 


### PR DESCRIPTION
From the line **250** to **255**, there is a func called merge_groups().
the code is as follows:
```
    def merge_groups(self):
        path_group = self.svg_path_groups[0]
        for path_group in self.svg_path_groups[1:]:
            path_group.svg_paths.extend(path_group.svg_paths)
        self.svg_path_groups = [path_group]
        return self
```
The variable path_group is being reused in the for loop, which causes confusion to me when I use this function. Inside the loop, **path_group.svg_paths.extend(path_group.svg_paths)** doesn't make sense because it is trying to extend path_group.svg_paths with itself. This is likely an error.
I think it is should be(the **\*\*group\*\*** is the difference between the two codes):
```
    def merge_groups(self):
        path_group = self.svg_path_groups[0]
        for **group** in self.svg_path_groups[1:]:
            path_group.svg_paths.extend(**group**.svg_paths)
        self.svg_path_groups = [path_group]
        return self
```
I use a different variable name (**group**) in the for loop. Here, path_group.svg_paths.extend(group.svg_paths) correctly extends the svg_paths of the first group.
Hopefully, You can notice this message.